### PR TITLE
Do not modify copied file permissions by default

### DIFF
--- a/src/hards/filesystem.py
+++ b/src/hards/filesystem.py
@@ -195,7 +195,9 @@ class _FilesystemHasFilesMixin:
 
         return location
 
-    def add_file(self, file: Path, *, name: str | None = None) -> None:
+    def add_file(
+        self, file: Path, *, name: str | None = None, permissions: int | None = None
+    ) -> None:
         super().add_file(file, name=name)
         if not file.exists() or not file.is_file:
             error_msg = (
@@ -208,7 +210,8 @@ class _FilesystemHasFilesMixin:
         destination = self._files_location / new_name
 
         shutil.copy2(file, destination, follow_symlinks=True)
-        Path(destination).chmod(0o400)
+        if permissions is not None:
+            Path(destination).chmod(0o400)
         self._files.append(new_name)
 
 

--- a/tests/test_filesystem_dataset.py
+++ b/tests/test_filesystem_dataset.py
@@ -64,6 +64,20 @@ def test_dataset_files(filesystem_dataset, data_assets):
         assert f.read() == "file data!\n"
 
 
+def test_dataset_files_overwrite(filesystem_dataset, data_assets):
+    filesystem_dataset.add_file(data_assets / "example_file.dat")
+    filesystem_dataset.add_file(data_assets / "example_file.dat")
+    assert filesystem_dataset.has_file("example_file.dat")
+
+
+def test_dataset_files_permissions(filesystem_dataset, data_assets):
+    filesystem_dataset.add_file(data_assets / "example_file.dat", permissions=0o400)
+    assert filesystem_dataset.has_file("example_file.dat")
+
+    with pytest.raises(PermissionError):
+        filesystem_dataset.add_file(data_assets / "example_file.dat")
+
+
 def test_dataset_same_from_scratch(filesystem_dataset):
     filesystem_dataset.add_data({"test_data_1": 2e4, "test_data_2": 1.4})
 


### PR DESCRIPTION
When adding a file to a dataset/datapoint, the permission of the file was being modified
https://github.com/ukaea/HARDS/blob/8929382bebf280ba5901f0c79930de19d46696be/src/hards/filesystem.py#L211

However this then violates the API by not allowing a file to be updated
https://github.com/ukaea/HARDS/blob/8929382bebf280ba5901f0c79930de19d46696be/src/hards/api.py#L222-L223